### PR TITLE
Add options to `amqp.publish` to allow binding do queues by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.3.0 (Unreleased)
+
+* Allow publishers to bind queues on publish even if no consumers are up.
+
 ## Version 1.1.0 to 1.2.0 (Mar 18)
 
 * Allow clients to specify a block to be called when an uncaught exception happens

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 ## Usage
 
-For now only AMQP is supported with topic exchanges.
+For now only AMQP is supported with *topic* exchanges.
 
 ```ruby
   # consumer.rb
-  amqp = Traffiq::AMQP.new(queue_url)
+  amqp = Traffiq::AMQP.new("user:password@rabbit-server.com")
   amqp.define_exchange('events', durable: true)
   amqp.subscribe('routing_key', options) do |delivery_info, metadata, payload| 
     puts delivery_info, metadata, payload
@@ -27,6 +27,29 @@ By default, the exchanges created will be `durable`. Please note that the
 producer and the consumer need to agree on the exchange options.
 
 Queues will be created with `durable: true, auto_delete: false`.
+
+More documentation can be found in the code as inline comments.
+
+### Publishing Messages
+
+Be aware that, by design, `topic` exchanges will drop any message sent to a
+queue that has never been binded to. So you will need to make sure your
+consumers start before the producer (and bind to a specific queue) before you
+send messages to them.
+
+You can force the publisher to bind to a queue with the `bind_to_queue`
+option on the `#publish` method. This will create a queue with the same name of
+the routing key, so be careful with that. You don't want to have many durable
+queues created by temporary proccesses.
+
+```ruby
+amqp = Traffiq::AMQP.new("server")
+amqp.publish('routing_key', payload)
+amqp.queues['routing_key] # => nil
+
+amqp.publish('routing_key', payload, bind_to_queue: true)
+amqp.queues['routing_key'] # => Bunny::Queue
+```
 
 ## Test Helpers
 
@@ -48,7 +71,6 @@ amqp.publish(routing_key, { tony: 'montana' }.to_json)
 last_amqp_queue_message(queue) # => { 'tony' => 'montana' }
 ```
 
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -61,6 +83,20 @@ gem 'traffiq'
 And then execute:
 
     $ bundle
+
+## Running Tests
+
+Traffiq requires RabbitMQ to be running for tests. So after you start your
+rabbit server, you can test with Rake:
+
+```
+bundle exec rake test
+```
+
+You can pass the Rabbit URL via the `QUEUE_URL` environment variable. If you are
+running Rabbit with the default configuration you don't need this. Same goes for
+Boxen, Traffiq will detect if you have Boxen installed and use the Boxen default
+port (55672).
 
 ## Contributing
 

--- a/lib/traffiq/amqp.rb
+++ b/lib/traffiq/amqp.rb
@@ -56,9 +56,10 @@ module Traffiq
       end
     end
 
-    def publish(routing_key, arguments = {})
+    def publish(routing_key, payload = {}, options = {})
       raise Traffiq::NoExchangeError.new if @exchange.nil?
-      @exchange.publish(MultiJson.dump(arguments), routing_key: routing_key, persistent: true)
+      bind_queue(routing_key) if options[:bind_to_queue]
+      @exchange.publish(MultiJson.dump(payload), routing_key: routing_key, persistent: true)
     end
 
     def close

--- a/lib/traffiq/amqp.rb
+++ b/lib/traffiq/amqp.rb
@@ -11,30 +11,52 @@ module Traffiq
       @channel = @conn.create_channel
     end
 
+    # Checks if the connection to the Rabbit server is opened.
     def connected?
       @conn.connected? && @channel.open?
     end
 
+    # Returns the exchanges that the channel has, except the default exchange.
     def exchanges
       @channel.exchanges
     end
 
+    # Returns the queues that are binded on this connection.
     def queues
       @channel.queues
     end
 
+    # Sets up the block to run when an error happens.
+    #
+    # @param [Block] block The block to run on uncaught exceptions.
     def on_uncaught_exception(&block)
       @channel.on_uncaught_exception(&block)
     end
 
-    def define_exchange(exchange_name, options = {})
+    # Defines a *topic* exchange.
+    #
+    # This defines a durable topic exchange by default.
+    #
+    # @param [String] name The name of the exchange.
+    # @param [Hash] options The options to define the exchange with.
+    #
+    # For options, look at Bunny's exchange options.
+    #     http://rubybunny.info/articles/exchanges.html
+    def define_exchange(name, options = {})
       options = {
         durable: true,
       }.merge(options)
-      @exchange = @channel.topic(exchange_name, options)
+      @exchange = @channel.topic(name, options)
     end
 
-    def bind_queue(routing_key, options = {})
+    # Binds a queue to the exchange and sets it's routing_key to `name`.
+    #
+    # @param [String] name The name of the queue and routing key to use.
+    # @param [Hash] options Queue options.
+    #
+    # For options look at Bunny's Queue options.
+    #     http://rubybunny.info/articles/queues.html
+    def bind_queue(name, options = {})
       raise Traffiq::NoExchangeError.new if @exchange.nil?
 
       options = {
@@ -42,10 +64,21 @@ module Traffiq
         auto_delete: false,
       }.merge(options)
 
-      @channel.queue(routing_key, options)
-              .bind(@exchange, routing_key: routing_key)
+      @channel.queue(name, options)
+              .bind(@exchange, routing_key: name)
     end
 
+    # Subscribes to a specific routing_key. Executes the block when there's a
+    # message routed there.
+    #
+    # A queue will be binded with the `routing_key` name.
+    #
+    # @param [String]  routing_key Routing key to subscribe to.
+    # @param [Hash] options Subscribe options for the queue.
+    # @param [Block] &block the block you want to execute when a message arrive.
+    #
+    # For options look at Bunny's Queue#subscribe options.
+    #     http://rubybunny.info/articles/queues.html
     def subscribe(routing_key, options = {}, &block)
       q = bind_queue(routing_key)
       options = options.merge(manual_ack: true)
@@ -56,12 +89,20 @@ module Traffiq
       end
     end
 
+    # Publishes a message to a specific routing key.
+    #
+    # @param [String] routing_key The routing key where you want to send the message to.
+    # @param [Hash] payload What you want the message to have. It'll be converted to JSON.
+    # @param [Hash] options Publish options
+    #
+    # @option opts [Boolean] :bind_to_queue If you want to bind a queue just in case there are no subscribers.
     def publish(routing_key, payload = {}, options = {})
       raise Traffiq::NoExchangeError.new if @exchange.nil?
       bind_queue(routing_key) if options[:bind_to_queue]
       @exchange.publish(MultiJson.dump(payload), routing_key: routing_key, persistent: true)
     end
 
+    # Closes connection to the Rabbit server.
     def close
       @channel.close
       @conn.close

--- a/test/lib/traffiq/amqp_test.rb
+++ b/test/lib/traffiq/amqp_test.rb
@@ -84,6 +84,17 @@ module Traffiq
             once
           amqp.publish('test_routing_key', payload)
         end
+
+        it "doesn't bind to a queue by default" do
+          amqp.publish('test_routing_key', payload)
+          assert_empty amqp.queues
+        end
+
+        it "binds to a queue if you want it to" do
+          amqp.publish('test_routing_key', payload, bind_to_queue: true)
+          refute_empty amqp.queues
+          refute_nil amqp.queues['test_routing_key']
+        end
       end
     end
 


### PR DESCRIPTION
RabbitMQ topic exchanges will drop messages if there are no subscribers to
a routing key. This means all consumers should be up before the producer or
we will lose messages. This is by design, since Rabbit won't like to have a
lot of queues that are just created and never consumed.

But for some special cases you'll want the queue to be created even if the
consumers are not up yet, so here we'll add the ability to do that.
